### PR TITLE
AG | Fix failing remote DB tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,10 @@ scalaVersion := "2.11.7"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
-scalacOptions ++= Seq("-Xmax-classfile-name", "254")
+scalacOptions ++= Seq("-Xmax-classfile-name", "128")
 
 libraryDependencies ++= {
-  val akkaStreamVersion = "1.0"
+  val akkaStreamVersion = "2.0.2"
   val akkaVersion = "2.3.14"
   val h2Version = "1.4.187"
   val hikariCpVersion = "2.3.12"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -44,6 +44,7 @@ db = {
       driver = "slick.driver.PostgresDriver$"
       url = ${WHEREAT_TEST_DATABASE_URL_1}
     }
+    connectionTimeout = 5 seconds
     numThreads = 10
   }
 
@@ -53,6 +54,7 @@ db = {
       driver = "slick.driver.PostgresDriver$"
       url = ${WHEREAT_TEST_DATABASE_URL_2}
     }
+    connectionTimeout = 5 seconds
     numThreads = 10
   }
 }

--- a/src/main/scala/io/whereat/db/LocationDao.scala
+++ b/src/main/scala/io/whereat/db/LocationDao.scala
@@ -28,9 +28,7 @@ trait LocationDao extends LocationQueries {
   val db: Database
 
   def hasSchema : Future[Boolean] =
-    db.run { MTable.getTables } map { ts ⇒
-      ts.exists { _.name.name == "LOCATIONS" }
-    }
+    db.run { MTable.getTables } map { _.exists(_.name.name == "LOCATIONS") }
 
   def build : Future[Boolean] = hasSchema flatMap { exists ⇒
     if (!exists) db.run { createSchema } flatMap { _ ⇒ Future.successful(true) }

--- a/src/test/scala/io/whereat/actor/ErasableSpec.scala
+++ b/src/test/scala/io/whereat/actor/ErasableSpec.scala
@@ -53,7 +53,7 @@ class ErasableSpec(_system: ActorSystem)
       "schedule periodic erasures of the DB" in {
 
         val interval = 200 milli
-        val offset = 10 milli
+        val offset = 20 milli
         val eraseActorRef = TestActorRef(new EraseActor)
 
         scheduleErase(system, testActor, fakeDao, interval)

--- a/src/test/scala/io/whereat/config/EnvironmentSpec.scala
+++ b/src/test/scala/io/whereat/config/EnvironmentSpec.scala
@@ -18,7 +18,7 @@
 package io.whereat.config
 
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Seconds, Span}
+import org.scalatest.time.{Seconds, Span, Millis}
 import org.scalatest.{Matchers, WordSpecLike}
 import slick.jdbc.meta.MTable
 
@@ -30,7 +30,9 @@ class EnvironmentSpec extends WordSpecLike
 with Matchers
 with ScalaFutures {
 
-  implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds))
+  implicit override val patienceConfig = PatienceConfig(
+    timeout = Span(10, Seconds),
+    interval = Span(100, Millis))
 
   "`#of`" should {
 
@@ -57,6 +59,10 @@ with ScalaFutures {
       val db = Environment.dbFor(Prod)
       db.run(MTable.getTables).futureValue should not be empty
 
+      /*whenReady(db.run(MTable.getTables)) { ts ⇒
+        ts should not be empty
+      }
+      */
       db.shutdown.futureValue
     }
 


### PR DESCRIPTION
- BUG: connecting to remote DBs (and other time-based testing snafus) were causing tests to pass in a non-deterministic fashion
- CAUSE: several timeout values were lower than necessary and hard to change
- FIX: figure out how to increase the timeout values and do it!
- NOTE: I can run the test suite 20 times in a row and get no failures. Would be great if others could try to replicate that...

(See commit message for implementation details...)
