### PR TITLE
AG | Add lenient DB timeout to dev, prod

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -26,6 +26,7 @@ db = {
       driver = "slick.driver.PostgresDriver$"
       url = ${WHEREAT_DEV_DATABASE_URL}
     }
+    connectionTimeout = 5 seconds
     numThreads = 10
   }
 
@@ -35,6 +36,7 @@ db = {
       driver = "slick.driver.PostgresDriver$"
       url = ${WHEREAT_PROD_DATABASE_URL}
     }
+    connectionTimeout = 5 seconds
     numThreads = 10
   }
 


### PR DESCRIPTION
To ensure db connection tests pass and build succeeds,
add more lenient timeout threshold to remote DB connections
for prod & dev (instead of just test DBs)
