### PR TITLE
[#M131] - AJ/AG - Erase dao before running tests

### DIFF
--- a/src/test/scala/io/whereat/db/LocationDaoSpec.scala
+++ b/src/test/scala/io/whereat/db/LocationDaoSpec.scala
@@ -44,6 +44,7 @@ class LocationDaoSpec
     (
       for {
         _ ← dao.build
+        _ ← dao.erase
         _ ← dao.db.run(insert(s17))
       } yield ()
     ).futureValue

--- a/src/test/scala/io/whereat/db/LocationQueriesSpec.scala
+++ b/src/test/scala/io/whereat/db/LocationQueriesSpec.scala
@@ -26,9 +26,6 @@ import io.whereat.support.SampleData.{n17, s17, s17_}
 
 import scala.concurrent.Future
 
-/**
- * License: GPLv3 (https://www.gnu.org/licenses/gpl-3.0.html)
- */
 
 class LocationQueriesSpec
   extends WordSpec
@@ -49,6 +46,9 @@ class LocationQueriesSpec
       .flatMap(exists ⇒
           if(!exists) db.run(createSchema)
           else Future.successful(())
+      )
+      .flatMap( _ =>
+        db.run(clear)
       ).futureValue
   }
   after {


### PR DESCRIPTION
Tests will always fail when the test record has been left in the database (possibly by an aborted db integration test). This always erases the database before running the tests to 
