### PR TITLE
[#M122] AG/JV | Fix dumbest typo ever

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
-11
+
 enablePlugins(JavaAppPackaging)
 
 name := "whereat-server"


### PR DESCRIPTION
- Whoops! `11` doesn't belong in the build file!
