### PR TITLE
Use sbt plugin for (stopgap) Heroku deploy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,3 +37,7 @@ To run the generated image:
 ```
 docker run -it whereat/whereat-location-server bash
 ```
+
+# Deploying
+
+run `sbt stage deployHeroku` from the root of this project 

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: target/universal/stage/bin/whereat-location-server

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: target/universal/stage/bin/whereat-server
+web: target/universal/stage/bin/whereat-location-server

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,8 @@ assemblyMergeStrategy in assembly := {
     old(x)
 }
 
+herokuAppName in Compile := "whereat-location-server"
+
 libraryDependencies ++= {
   val akkaStreamVersion = "2.0.3"
   val akkaVersion = "2.3.14"

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
 
 enablePlugins(JavaAppPackaging)
 
-name := "whereat-server"
+name := "whereat-location-server"
 
 version := "1.0"
 


### PR DESCRIPTION
## Motivation:

To reduce heroku footprint while we migrate to AWS?eclips.is, we removed remote databases and standardized around H2. To reap the benefits, we need to redeploy, but current app is not compatible with git interface, thus we use sbt's heroku deploy plugin. With this PR, we gain the ability to run only 1 server on Heroku without any remote databases, saving ~$150/mo. Woohoo!
## Steps:
- add heroku app name to `build.sbt` (plugin already included in `plugins.sbt`)
- add usage instructions in `CONTRIBUTING.md`
## Side-effects:
- change all instances of `whereat-server` to `whereat-location-server` 
